### PR TITLE
nix(NixOS)でlibaribcaptionのインストールができない問題を修正

### DIFF
--- a/libaribcaption.pc.in
+++ b/libaribcaption.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@


### PR DESCRIPTION
nix(NixOS)でlibaribcaptionのインストールができない問題を修正します。
修正前は、以下のようなエラーが出てライブラリのインストールが失敗sました。

https://gist.github.com/vroad/61ae35dd7c31af9b14b88482ca9d1dee

相対パスが入っているCMAKE_INSTALL_LIBDIRとprefixを連結するのではなく、
エラーメッセージで提案されている内容に従い
フルパスが入るCMAKE_INSTALL_FULL_LIBDIRを使用するように変えると正常に動きます。

ビルドに使用したnixファイル:
```nix
{ stdenv
, fetchFromGitHub
, cmake
, fontconfig
}:

stdenv.mkDerivation rec {
  name = "libaribcaption";
  version = "d333768309a8a757f0f3879b44737bce69444022";

  buildInputs = [ cmake fontconfig ];

  src = fetchFromGitHub {
    owner = "xqq";
    repo = "libaribcaption";
    rev = version;
    sha256 = "sha256-39gBJ+ac1cY4eBiI2Bz8qMZdd06SihmL3ZaFmULTivs=";
  };
}
```