### PR TITLE
decoder/decoder_impl: Fix possible out-of-range accesses or exceptions, etc.

### DIFF
--- a/src/renderer/font_provider_directwrite.cpp
+++ b/src/renderer/font_provider_directwrite.cpp
@@ -138,6 +138,9 @@ auto FontProviderDirectWrite::GetFontFace(const std::string& font_name,
     std::wstring wide_font_name = wchar::UTF8ToWideString(converted_family_name);
 
     LOGFONTW lf = {0};
+    if (wide_font_name.length() >= std::size(lf.lfFaceName)) {
+        return Err(FontProviderError::kFontNotFound);
+    }
     wcscpy_s(lf.lfFaceName, wide_font_name.c_str());
     lf.lfWeight = FW_NORMAL;
     lf.lfCharSet = DEFAULT_CHARSET;

--- a/src/renderer/font_provider_gdi.cpp
+++ b/src/renderer/font_provider_gdi.cpp
@@ -138,6 +138,9 @@ auto FontProviderGDI::GetFontFace(const std::string& font_name, std::optional<ui
     std::wstring wide_font_name = wchar::UTF8ToWideString(converted_family_name);
 
     LOGFONTW lf{};
+    if (wide_font_name.length() >= std::size(lf.lfFaceName)) {
+        return Err(FontProviderError::kFontNotFound);
+    }
     wcscpy_s(lf.lfFaceName, wide_font_name.c_str());
     lf.lfWeight = FW_NORMAL;
     lf.lfCharSet = DEFAULT_CHARSET;


### PR DESCRIPTION
Conversion from bits to bytes for `bitmap_size` should be round-up, otherwise overruns may occur in `DRCSRenderer::DRCSToColoredBitmap` in minor cases.