### PR TITLE
Add missing includes

### DIFF
--- a/src/common/caption_capi.cpp
+++ b/src/common/caption_capi.cpp
@@ -19,6 +19,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <new>
+#include <stdlib.h>
 #include "aribcaption/caption.h"
 #include "aribcaption/caption.hpp"
 #include "base/utf_helper.hpp"


### PR DESCRIPTION
This file uses std::nothrow which is declared in <new>, and free() which is declared in stdlib.h.

Previously, these declarations have been included implicitly through transitive include files. However, libc++ will soon reduce the number of extra transitive include files [1], and when this happens, building fails unless <new> and <stdlib.h> explicitly are included here.

[1] https://discourse.llvm.org/t/rfc-remove-unused-transitive-includes-from-the-libc-headers/90157